### PR TITLE
Improved README, interpolate in extrapolate, and remove DOY

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FIRITools"
 uuid = "13f5a3bc-1e41-4c76-a7e5-29a214aba9ea"
 authors = ["fgasdia <17058025+fgasdia@users.noreply.github.com>"]
-version = "0.0.2"
+version = "0.0.3"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,60 @@ The Faraday-International Reference Ionosphere (FIRI) is a semiempirical model o
 
 ## Usage
 
+Only one function is exported from FIRITools: `firi`. `firi` returns the average profile after filtering the model by the keyword arguments to the function.
+
+```julia
+profile = firi(; chi=(0, 130), lat=(0, 60), f10_7=(75, 200), month=(1, 12))
+```
+
+Each of the keyword arguments can either be a `Tuple` that inclusively brackets the range of values to be included in the average profile or can be a single value. Note that no interpolation occurs! If the value specified for `f10_7` is `100` (which is not one of the values in the model output) then a warning will be printed and an empty profile will be returned.
+
+The raw model data can be accessed as `FIRITools.ALTITUDE` for a `Vector` of the altitude in meters, `FIRITools.DATA` for a matrix of each electron density profile in electrons per cubic meter, and `FIRITools.HEADER` for a `DataFrame` with each combination of FIRI model parameters. To find the acceptable values of the `f10_7` field, for example, you can use
+
+```julia
+unique(FIRITools.HEADER[!,"F10_7"])
+```
+
+Although day of year ("DOY") appears as an independent field in the original published FIRI model file, this is entirely redundant with the month number. Each day of year simply corresponds to the day number in the middle of each month. Therefore, we use only the month field.
+
+The keyword defaults bracket the full range of each field so that no filtering occurs.
+
+### Interpolation across latitude and solar zenith angle
+
+The latitude and solar zenith angle (`chi`) fields can be interpolated with the function form
+
+```julia
+profile = firi(chi, lat; f10_7=(75, 200), month=(1, 12))
+```
+
+This performs a simple linear interpolation at each altitude of the profile for the specified `chi` and `lat`. The latitude can also be linearly extrapolated beyond 60°. If a `chi` or `lat` less than 0° is provided, a warning is thrown. According to Friedrich et al., 2018, although FIRI is only valid for the Northern Hemisphere, it can be used to predict values for the Southern Hemisphere by adding 6 months. Any `chi` greater than 130° (night) returns the profiles for exactly 130°.
+
+### Quantiles
+
+The average profile returned by `firi` is skewed towards higher electron densities. If preferred, profile quantiles can be returned with the function `FIRITools.quantile`. The quantile function is not exported to avoid collisions with `Statistics.quantile`. The usage of `FIRITools.quantile` is similar to `firi`, except the quantile(s) are specified by `p` on the interval [0, 1].
+
+```julia
+profile = quantile(p; chi=(0, 130), lat=(0, 60), f10_7=(75, 200), month=(1, 12))
+```
+
+There is also an interpolating form
+
+```julia
+profile = quantile(chi, lat, p; f10_7=(75, 200), month=(1, 12))
+```
+
+### Extrapolation by altitude
+
+To extrapolate the bottom of a profile to lower altitudes, use `FIRI.extrapolate`. This function will also interpolate to new (finer or coarser) altitudes in `newz`.
+
+The function call is
+
+```julia
+newprofile = extrapolate([z,] profile, newz; max_altitude=nothing, N=nothing)
+```
+
+`max_altitude` is the maximum altitude from the bottom up of `z` used to build the exponential extrapolation. If `N` is provided, then `N` samples of the profile are used from the bottom up of `z`.
+
 ## Citations
 
 Friedrich, M., and Torkar, K. M. (2001). FIRI: A semiempirical model of the lower ionosphere. Journal of Geophysical Research: Space Physics, 106, 21409-21418. [doi: 10.1029/2001JA900070](https://doi.org/10.1029/2001JA900070)

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -73,7 +73,7 @@ for la in interp_lat
           linestyle=:dash)
 end
 display(p)
-savefig("alt.png")
+savefig("lat.png")
 
 real_sza = unique(FIRITools.HEADER[!,"Chi, deg"])
 chis = 0:5:130
@@ -101,7 +101,6 @@ savefig(p, "sza.png")
 real_sza = [75, 80, 85, 90, 95, 100]
 chis = 75:100
 interp_sza = setdiff(chis, real_sza)
-# interp_sza = 89
 N = length(chis)
 cmap = palette(:rainbow, N, rev=true)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,8 +58,11 @@ using CSV, DataFrames
     # plot(ref30.ne, ref30.alt, label="Wei 30", xlims=(10^4, 4e10), ylims=(55, 110), xscale=:log10)
     # plot!(FIRITools.quantile(chi=(0, 95), 0.3), FIRITools.ALTITUDE, label=30, xscale=:log10)
 
-    p1 = FIRITools.extrapolate(FIRITools.ALTITUDE, firi(), 30e3:1e3:120e3; max_altitude=60e3)
-    p2 = FIRITools.extrapolate(FIRITools.ALTITUDE, firi(), 30e3:1e3:120e3; N=6)
+    @test_throws ArgumentError FIRITools.extrapolate(firi(), 30e3:1e3:120e3)
+
+    firialt = minimum(FIRITools.ALTITUDE):1000:maximum(FIRITools.ALTITUDE)
+    p1 = FIRITools.extrapolate(firialt, firi(), 30e3:1e3:120e3; max_altitude=60e3)
+    p2 = FIRITools.extrapolate(firialt, firi(), 30e3:1e3:120e3; N=6)
     p3 = FIRITools.extrapolate(firi(), 30e3:1e3:120e3; max_altitude=60e3)
     p4 = FIRITools.extrapolate(firi(), 30e3:1e3:120e3; N=6)
 
@@ -87,4 +90,7 @@ using CSV, DataFrames
     p11 = FIRITools.extrapolate(FIRITools.DATA[:,[1, 2]], 30e3:1e3:120e3, N=6)
     @test p11[:,1] == FIRITools.extrapolate(FIRITools.DATA[:,1], 30e3:1e3:120e3, N=6)
     @test p11[:,2] == FIRITools.extrapolate(FIRITools.DATA[:,2], 30e3:1e3:120e3; N=6)
+
+    newz = 30e3:250:110e3
+    @test length(FIRITools.extrapolate(firi(), newz, N=6)) == length(newz)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,7 +77,7 @@ using CSV, DataFrames
     @test p1 == p2
     @test p1 == p3
     @test p1 == p4
-    @test p1[60 .< 30:120] == firi()[60e3 .< FIRITools.ALTITUDE .<= 120e3]
+    @test p1[60 .< 30:120] ≈ firi()[60e3 .< FIRITools.ALTITUDE .<= 120e3]
     @test p1[70 .<= 30:120] == p5
 
     # plot(firi(), FIRITools.ALTITUDE, xscale=:log10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,14 +4,14 @@ using CSV, DataFrames
 
 @testset "FIRITools.jl" begin
     @test size(FIRITools.DATA) == (94, 1980)  # for firi2018
-    @test size(FIRITools.HEADER) == (1980, 6)
+    @test size(FIRITools.HEADER) == (1980, 5)
 
     @test FIRITools.twoclosest(FIRITools.HEADER[!,"Chi, deg"], 90) == [90, 90]
     @test FIRITools.twoclosest(FIRITools.HEADER[!,"Chi, deg"], 89) == [85, 90]
     @test FIRITools.twoclosest(FIRITools.HEADER[!,"Chi, deg"], 135) == [100, 130]
 
     @test size(FIRITools.selectprofiles()) == (94, 1980)
-    @test size(FIRITools.selectprofiles(doy=(1, 180))) == (94, 1980÷2)
+    @test size(FIRITools.selectprofiles(month=(1, 6))) == (94, 1980÷2)
     @test_logs (:warn, "15 is not in model parameters. Looking for interpolating form of `selectprofiles`?") FIRITools.selectprofiles(chi=15) 
     
     # Try interpolating chi and lat. Should always have same size
@@ -30,8 +30,11 @@ using CSV, DataFrames
     # profiles causes there to be some crossing density regions
 
     @test size(firi()) == (94,)
-    @test size(firi(doy=(1, 180))) == (94,)
+    @test size(firi(month=(1, 6))) == (94,)
     @test size(firi(15, 10)) == (94,)
+
+    @test_throws ArgumentError firi(-10, 45)
+    @test_throws ArgumentError firi(30, -15)
     @test_logs (:warn, "`chi` greater than 130° uses `chi = 130°`") firi(160, 45)
 
     @test FIRITools.quantile(1, chi=(0, 90)) ==


### PR DESCRIPTION
- Usage section in README is filled in. Closes #5.

This contains breaking changes:

- `FIRITools.extrapolate` now interpolates to `newz` altitudes (in addition to extrapolating an exponential to lower altitudes)
- `doy` day of year keyword arguments have been removed because this is redundant with `month`